### PR TITLE
診断ページの調整

### DIFF
--- a/app/views/diagnoses/survey.html.erb
+++ b/app/views/diagnoses/survey.html.erb
@@ -6,7 +6,7 @@
   </h1>
 
   <% if @current_question %>
-    <div class="bg-white rounded-3xl shadow-xl p-8 w-full max-w-md md:max-w-lg border border-gray-200 flex flex-col items-center space-y-6 transition-all duration-300 ease-in-out">
+  <div class="bg-white rounded-3xl shadow-xl p-8 w-full max-w-lg mx-auto border border-gray-200 flex flex-col items-center space-y-6 transition-all duration-300 ease-in-out">
       <h2 class="text-lg md:text-xl font-semibold text-gray-700 text-center"><%= @current_question[:text] %></h2>
 
       <%= form_with url: (@current_question[:id] == 7 ? "/survey/finish" : "/survey/answer"), method: :post, local: true, class: "w-full flex flex-col items-center space-y-6" do |f| %>


### PR DESCRIPTION
PC版の設問が左寄りになっているのを修正（中央寄せに修正）